### PR TITLE
Cambio entre escenas Phaser y elementos DOM

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,7 +70,7 @@
         }
     </style>
 
-    <div id="info" class="info menu">
+    <div id="info" class="info menu" style="display: none;">
         <div class="fondo">
             <div name="sub-menu" id="controles" style="display: block;">
                 <h1><a href="#" onclick="toggleSubMenu('controles')">Controles</a></h1>
@@ -165,26 +165,6 @@
             color: blue;
         }
     </style>
-
-    <script>
-        function toggleInfo(){
-            if (document.getElementById("info").style.display == "flex")
-                document.getElementById("info").style.display = "none";
-            else
-                document.getElementById("info").style.display = "flex";
-        }
-
-        function toggleSubMenu(origen) {
-            if (compruebaContenido(origen)) {
-                apagaContenidoDirecto(origen);
-                muestraOtrosSubMenus();
-            } else {
-                muestraContenidoDirecto(origen);
-                apagaOtrosSubMenus(origen);
-            }
-        }
-
-    </script>
     
     <script id="magia-arcana" src="./lib/responsive.js" type="module"></script>
 

--- a/index.html
+++ b/index.html
@@ -148,7 +148,7 @@
     </style>
 
     <div id="ask" class="ask">
-        <a title="Consulta la información adicional" href="#" onclick="toggleInfo()"><i class="fa fa-question-circle" style="font-size: 5.25vh;" aria-hidden="true"></i></a>
+        <a title="Consulta la información adicional" href="#" onclick="pause()"><i class="fa fa-question-circle" style="font-size: 5.25vh;" aria-hidden="true"></i></a>
     </div>
 
     <style>
@@ -165,8 +165,16 @@
             color: blue;
         }
     </style>
+
+    <script>
+        function pause() {
+            const evt = createEvent('pause');
+            document.dispatchEvent(evt);
+        }        
+    </script>
     
     <script id="magia-arcana" src="./lib/responsive.js" type="module"></script>
+    <script id="magia-arcana" src="./lib/pauseCtrl.js" type="module"></script>
 
 </body>
 

--- a/lib/pauseCtrl.js
+++ b/lib/pauseCtrl.js
@@ -1,0 +1,40 @@
+import { gameLogic } from '../src/game.js'
+
+export function toggleInfo(){
+    if (document.getElementById("info").style.display == "flex")
+        document.getElementById("info").style.display = "none";
+    else
+        document.getElementById("info").style.display = "flex";
+}
+
+document.addEventListener('pause', (event) => {
+    togglePause();
+    console.log('pause event!!');
+});
+
+var isPaused = false;
+var lastScene = 'menuGame';
+function togglePause() {   
+
+    if (!isPaused) {      
+        if (gameLogic.scene.getScene('pvliGame').isActive()) 
+        {
+            gameLogic.scene.getScene('pvliGame').handlePause();
+            isPaused = true;
+            lastScene = 'pvliGame';
+        }
+        else if (gameLogic.scene.getScene('menuGame').isActive()) 
+        {
+            gameLogic.scene.getScene('menuGame').handlePause();
+            isPaused = true;
+            lastScene = 'menuGame';
+        }
+    }
+    else if (isPaused) {
+        gameLogic.scene.getScene('blankPause').handleResume(lastScene);
+        isPaused = false;
+    } else {
+        toggleInfo();
+    }
+
+};

--- a/lib/pauseCtrl.js
+++ b/lib/pauseCtrl.js
@@ -16,18 +16,11 @@ var isPaused = false;
 var lastScene = 'menuGame';
 function togglePause() {   
 
-    if (!isPaused) {      
-        if (gameLogic.scene.getScene('pvliGame').isActive()) 
-        {
-            gameLogic.scene.getScene('pvliGame').handlePause();
+    if (!isPaused) {
+        lastScene = getActiveScene();
+        if (lastScene != null && lastScene != 'blankPause') {
+            gameLogic.scene.getScene(lastScene).handlePause();
             isPaused = true;
-            lastScene = 'pvliGame';
-        }
-        else if (gameLogic.scene.getScene('menuGame').isActive()) 
-        {
-            gameLogic.scene.getScene('menuGame').handlePause();
-            isPaused = true;
-            lastScene = 'menuGame';
         }
     }
     else if (isPaused) {
@@ -37,4 +30,21 @@ function togglePause() {
         toggleInfo();
     }
 
+};
+
+function getActiveScene() {
+    let nameScene = '';
+    let cont = 0;
+    gameLogic.scene.scenes.forEach(scene => {
+        if (scene.scene.key != 'boot' && scene.isActive()) {
+            nameScene = scene.scene.key;
+            cont++;
+        }
+    });
+
+    if (cont == 1) return nameScene; 
+    else {
+        console.log('ERROR: demasiadas escenas activas!');
+        return null;
+    }
 };

--- a/lib/submenus.js
+++ b/lib/submenus.js
@@ -1,3 +1,4 @@
+
 function compruebaContenido(origen) {
     return document.getElementById('content-' + origen).style.display == 'block';
 }
@@ -35,3 +36,24 @@ function apagaContenido(origen) {
         }
     }
 }
+
+function toggleInfo(){
+    if (document.getElementById("info").style.display == "flex")
+        document.getElementById("info").style.display = "none";
+    else
+        document.getElementById("info").style.display = "flex";
+}
+
+function toggleSubMenu(origen) {
+    if (compruebaContenido(origen)) {
+        apagaContenidoDirecto(origen);
+        muestraOtrosSubMenus();
+    } else {
+        muestraContenidoDirecto(origen);
+        apagaOtrosSubMenus(origen);
+    }
+}
+
+function togglePause(origen) {
+    toggleSubMenu(origen);
+};

--- a/lib/submenus.js
+++ b/lib/submenus.js
@@ -37,13 +37,6 @@ function apagaContenido(origen) {
     }
 }
 
-function toggleInfo(){
-    if (document.getElementById("info").style.display == "flex")
-        document.getElementById("info").style.display = "none";
-    else
-        document.getElementById("info").style.display = "flex";
-}
-
 function toggleSubMenu(origen) {
     if (compruebaContenido(origen)) {
         apagaContenidoDirecto(origen);
@@ -54,6 +47,25 @@ function toggleSubMenu(origen) {
     }
 }
 
-function togglePause(origen) {
-    toggleSubMenu(origen);
-};
+function createEvent (name) {
+    var evt = document.createEvent('Event')
+    evt.initEvent(name)
+    return evt
+}
+
+/** @deprecated es una chuleta de uso */
+function createEventINFO() {
+    // Create the event.
+    const event = document.createEvent('Event');
+
+    // Define that the event name is 'build'.
+    event.initEvent('build', true, true);
+
+    // Listen for the event.
+    elem.addEventListener('build', (e) => {
+    // e.target matches elem
+    }, false);
+
+    // Target can be any Element or other EventTarget.
+    elem.dispatchEvent(event);
+}

--- a/src/game.js
+++ b/src/game.js
@@ -7,6 +7,7 @@ import Boot from './scenes/boot.js';
 import GameLogic from './scenes/pvliGame.js';
 import Menu from './scenes/menu.js';
 import GameOver from './scenes/gameOver.js';
+import BlankPause from './scenes/blankPause.js';
 
 window.onload = cargarJuego();
 
@@ -23,7 +24,7 @@ export function cargarJuego() {
             // autoCenter: Phaser.Scale.Center.CENTER_HORIZONTALLY
         },
         pixelArt: true,
-        scene: [ Boot, GameLogic, Menu, GameOver ],
+        scene: [ Boot, GameLogic, Menu, GameOver, BlankPause ],
         physics: {
             default: 'arcade',
             arcade: {

--- a/src/game.js
+++ b/src/game.js
@@ -11,6 +11,7 @@ import BlankPause from './scenes/blankPause.js';
 
 window.onload = cargarJuego();
 
+export var gameLogic;
 export function cargarJuego() {
     const config = {
         type: Phaser.AUTO,
@@ -31,13 +32,14 @@ export function cargarJuego() {
                 gravity: {
                     y: 200
                 },
-                debug: true // for showing box-colliders
+                debug: true // use this to show box-colliders
             }
         }
         
     };
 
-    var game = new Phaser.Game(config);
+    gameLogic = new Phaser.Game(config);
+    // console.log(gameLogic);
 };
 
 // ---------------------------------

--- a/src/scenes/blankPause.js
+++ b/src/scenes/blankPause.js
@@ -1,0 +1,39 @@
+import {} from '../../lib/submenus.js'
+
+export default class blankPause extends Phaser.Scene
+{
+    /**
+     * Constructor de la escena
+     */
+    constructor() 
+    {
+        super({
+            key: 'blankPause'
+        });
+    }
+
+    init()
+    {
+        this.p = this.input.keyboard.addKey('P');
+        togglePause();
+    }
+
+    preload() 
+    {
+        console.log("blankPause scene")
+    }
+
+    create() 
+    {
+    }
+
+    update(t, dt) 
+    {
+        // pause logic
+        if (this.p.isDown) {
+            this.scene.resume('pvliGame');
+            this.scene.stop();
+            console.log("UN-PAUSE");
+        }
+    }
+};

--- a/src/scenes/blankPause.js
+++ b/src/scenes/blankPause.js
@@ -1,4 +1,4 @@
-import {} from '../../lib/submenus.js'
+import '../../lib/submenus.js'
 
 export default class blankPause extends Phaser.Scene
 {
@@ -15,7 +15,8 @@ export default class blankPause extends Phaser.Scene
     init()
     {
         this.p = this.input.keyboard.addKey('P');
-        togglePause();
+        toggleInfo();
+        // console.log(document.getElementById('info'));
     }
 
     preload() 
@@ -29,8 +30,13 @@ export default class blankPause extends Phaser.Scene
 
     update(t, dt) 
     {
+        this.handleResume();
+    }
+
+    handleResume() {
         // pause logic
         if (this.p.isDown) {
+            toggleInfo();
             this.scene.resume('pvliGame');
             this.scene.stop();
             console.log("UN-PAUSE");

--- a/src/scenes/blankPause.js
+++ b/src/scenes/blankPause.js
@@ -1,4 +1,4 @@
-import '../../lib/submenus.js'
+import { toggleInfo } from '../../lib/pauseCtrl.js'
 
 export default class blankPause extends Phaser.Scene
 {
@@ -16,7 +16,6 @@ export default class blankPause extends Phaser.Scene
     {
         this.p = this.input.keyboard.addKey('P');
         toggleInfo();
-        // console.log(document.getElementById('info'));
     }
 
     preload() 
@@ -30,16 +29,17 @@ export default class blankPause extends Phaser.Scene
 
     update(t, dt) 
     {
-        this.handleResume();
+        if (this.p.isDown) {
+            const evt = createEvent('pause');
+            document.dispatchEvent(evt);
+        }
     }
 
-    handleResume() {
+    handleResume(scene) {
         // pause logic
-        if (this.p.isDown) {
-            toggleInfo();
-            this.scene.resume('pvliGame');
-            this.scene.stop();
-            console.log("UN-PAUSE");
-        }
+        toggleInfo();
+        this.scene.resume(scene);
+        this.scene.stop();
+        console.log("UN-PAUSE");        
     }
 };

--- a/src/scenes/gameOver.js
+++ b/src/scenes/gameOver.js
@@ -40,7 +40,7 @@ export default class GameOver extends Phaser.Scene
         // click to play again
         this.input.keyboard.once('keydown-SPACE', () => {
             this.scene.start('menuGame')
-        })
+        });
     }
 
     update() 

--- a/src/scenes/menu.js
+++ b/src/scenes/menu.js
@@ -10,9 +10,13 @@ export default class Menu extends Phaser.Scene
         });
     }
 
+    init() {
+        this.p = this.input.keyboard.addKey('P');
+    }
+
     preload() 
     {
-        console.log("Menu scene")
+        console.log(" - Menu scene - ")
     }
 
     create() 
@@ -34,11 +38,20 @@ export default class Menu extends Phaser.Scene
         // three buttons, three levels on difficulty (0.35, 0.55, 0.75)
         this.createButtonGame(width * 0.5, height * 0.45, 'button', 'Jugar', 3)
         this.createButtonGame(width * 0.5, height * 0.65, 'button', 'Opciones', 3)
+
+        // pause ctrl
+        this.active = true;
+        this.events.on('resume', () => {
+            this.active = true;
+        })
     }
 
     update() 
     {
-
+        if (this.p.isDown) {
+            const evt = createEvent('pause');
+            document.dispatchEvent(evt);
+        }
     }
 
     /**
@@ -48,6 +61,18 @@ export default class Menu extends Phaser.Scene
     {
         // inits the game main scene
         this.scene.start('pvliGame', lv)
+        this.active = false;
+    }
+
+    isActive() { return this.active; }
+    toggleActive() { this.active = !this.active; }
+
+    handlePause() {
+        // pause logic
+        this.scene.pause();
+        this.scene.launch('blankPause');
+        this.active = false;
+        console.log("PAUSE");
     }
 
     /**

--- a/src/scenes/pvliGame.js
+++ b/src/scenes/pvliGame.js
@@ -45,6 +45,9 @@ export default class pvliGame extends Phaser.Scene
     objectCollected
     objectToFinish
 
+    /** @type {boolean} */
+    active
+
     /**
      * Constructor de la escena
      */
@@ -120,6 +123,12 @@ export default class pvliGame extends Phaser.Scene
 
         // Inits the timer
         this.timeLapsed = 0
+
+        // pause ctrl
+        this.active = true;
+        this.events.on('resume', () => {
+            this.active = true;
+        });
     }
 
     update(t, dt) 
@@ -133,17 +142,23 @@ export default class pvliGame extends Phaser.Scene
         //     this.createRandomBullet(this.map)
         //     this.timeLapsed = 0
         // }        
+        // this.input.keyboard.on('keydown_P', this.handlePause, this);
 
-        this.handlePause();
+        if (this.p.isDown) {
+            const evt = createEvent('pause');
+            document.dispatchEvent(evt);
+        }
     }
+
+    isActive() { return this.active; }
+    toggleActive() { this.active = !this.active; }
 
     handlePause() {
         // pause logic
-        if (this.p.isDown) {
-            this.scene.pause();
-            this.scene.launch('blankPause');
-            console.log("PAUSE");
-        }
+        this.scene.pause();
+        this.scene.launch('blankPause');
+        this.active = false;
+        console.log("PAUSE");
     }
 
     /**
@@ -288,6 +303,7 @@ export default class pvliGame extends Phaser.Scene
         // kill object and play feedback
         this.playerContainer.destroy()
         this.sound.play('lose')
+        this.scene.stop('pvliGame')
         this.scene.start('GameOver')
 
         // inits the game final scene

--- a/src/scenes/pvliGame.js
+++ b/src/scenes/pvliGame.js
@@ -83,6 +83,8 @@ export default class pvliGame extends Phaser.Scene
 
         // cancela las colisiones con el techo
         this.physics.world.checkCollision.up = false
+
+        this.p = this.input.keyboard.addKey('P');
     }
 
     preload() 
@@ -130,7 +132,14 @@ export default class pvliGame extends Phaser.Scene
         // {
         //     this.createRandomBullet(this.map)
         //     this.timeLapsed = 0
-        // }
+        // }        
+
+        // pause logic
+        if (this.p.isDown) {
+            this.scene.pause();
+            this.scene.launch('blankPause');
+            console.log("PAUSE");
+        }
     }
 
     /**
@@ -272,7 +281,7 @@ export default class pvliGame extends Phaser.Scene
      */
     handleGameLose()
     {
-            // kill object and play feedback
+        // kill object and play feedback
         this.playerContainer.destroy()
         this.sound.play('lose')
         this.scene.start('GameOver')

--- a/src/scenes/pvliGame.js
+++ b/src/scenes/pvliGame.js
@@ -134,6 +134,10 @@ export default class pvliGame extends Phaser.Scene
         //     this.timeLapsed = 0
         // }        
 
+        this.handlePause();
+    }
+
+    handlePause() {
         // pause logic
         if (this.p.isDown) {
             this.scene.pause();


### PR DESCRIPTION
Partiendo del anterior pull-request [#3 - menus html desplegables](https://github.com/Acedpol/PVLI-2022-23/pull/3), se ha continuado con la idea de introducir una escena que no pertenece al juego, propiamente desarrollado en Phaser, es decir, no pertenece al elemento DOM `<canvas>` lo que ha supuesto diversos conflictos que se han resuelto con mucha paciencia.

Importante es tener claro que Phaser es un framework que envuelve el juego, por tanto todo lo que sucede en el canvas.  
Además, hay que tener en cuenta las luchas predecesoras por hacerlo responsive en el pull-request [#2 - magia-arcana](https://github.com/Acedpol/PVLI-2022-23/pull/2).

A continuación los pasos seguidos:
1. Se ha realizado el cambio entre escenas dentro del juego, mediante utilidades de Phaser. Con el objetivo de pausar la escena actual y evitar cualquier interacción no deseada ya que deja de visualizarse, se ha creado una escena de pausa en blanco.
2. Ha sido importante diferenciar entre `text/javascript` (como texto plano añadido al documento html) de la otra posiblidad que es usar esos scripts de forma modular, es decir, como un módulo incrustado. 
> Lo que supone que los elementos DOM no conozcan lo que hay dentro del módulo pero sin embargo si conocerán lo que hay en un texto plano. Es importante si quieres añadir reacciones del tipo `onclick`; como también hay que tener en cuenta la ventajas de la versión modular que permite importar y exportar elementos y funciones entre diferentes ficheros.  
3. Por tanto, dado que se puede acceder siempre al documento desde donde sea, el cambio entre escenas dentro de los eventos de teclado del juego ha sido relativamente fácil. Pero el problema ha sido al querer mantener la misma funcionalidad en el botón que se encuentra al lado del título de la página web.
4. Dado que es un elemento que pertenece al DOM y no al juego, no puede acceder a las clases y métodos que componen la aplicación que es el juego. Para esto se ha encontrado una solución mediante `eventos y listeners` del DOM.
> Recuerda que un elemento del DOM no puede acceder a variables y funciones modulares.
5. Gracias a estos eventos personalizables del tipo de paso de mensajes. Se ha creado un fichero `pauseCtrl.js` que maneja todo lo perteneciente a estos eventos, lo que luego se ha reaprovechado más adelante para unificar los métodos. Este fichero tiene una copia del juego llamada `gameLogic` y desde accede a todo lo necesario dentro del juego, lo que se activa con los eventos.
6. Finalmente, para asegurar que solo hay una escena principal activa se ha añadido a las escena una condición de actividad y dicha condición permite localizar la escena que ha solicitado la pausa, para poder volver a esta desde la pausa.



