### PR TITLE
Herencia: escenas

### DIFF
--- a/lib/pauseCtrl.js
+++ b/lib/pauseCtrl.js
@@ -18,7 +18,7 @@ function togglePause() {
 
     if (!isPaused) {
         lastScene = getActiveScene();
-        if (lastScene != null && lastScene != 'blankPause') {
+        if (lastScene != null) {
             gameLogic.scene.getScene(lastScene).handlePause();
             isPaused = true;
         }

--- a/src/game.js
+++ b/src/game.js
@@ -5,9 +5,9 @@
 
 import Boot from './scenes/boot.js';
 import GameLogic from './scenes/pvliGame.js';
-import Menu from './scenes/menu.js';
+import Menu from './scenes/mainMenu.js';
 import GameOver from './scenes/gameOver.js';
-import BlankPause from './scenes/blankPause.js';
+import BlankPause from './scenes/pause.js';
 
 window.onload = cargarJuego();
 

--- a/src/scenes/blankPause.js
+++ b/src/scenes/blankPause.js
@@ -1,20 +1,19 @@
 import { toggleInfo } from '../../lib/pauseCtrl.js'
+import blankScene from './scene.js';
 
-export default class blankPause extends Phaser.Scene
+export default class blankPause extends blankScene
 {
     /**
      * Constructor de la escena
      */
     constructor() 
     {
-        super({
-            key: 'blankPause'
-        });
+        super('blankPause');
     }
 
     init()
     {
-        this.p = this.input.keyboard.addKey('P');
+        super.init();
         toggleInfo();
     }
 
@@ -29,17 +28,12 @@ export default class blankPause extends Phaser.Scene
 
     update(t, dt) 
     {
-        if (this.p.isDown) {
-            const evt = createEvent('pause');
-            document.dispatchEvent(evt);
-        }
+        super.update();
     }
 
+    /** @override */
     handleResume(scene) {
-        // pause logic
+        super.handleResume(scene);
         toggleInfo();
-        this.scene.resume(scene);
-        this.scene.stop();
-        console.log("UN-PAUSE");        
     }
 };

--- a/src/scenes/gameOver.js
+++ b/src/scenes/gameOver.js
@@ -1,6 +1,6 @@
-import blankScene from "./scene.js";
+import blankMenu from "./menu.js";
 
-export default class GameOver extends blankScene 
+export default class GameOver extends blankMenu
 {
     /**
      * Constructor de la escena
@@ -16,7 +16,7 @@ export default class GameOver extends blankScene
 
     preload() 
     {
-        console.log("GameOver scene")
+        console.log(" - gameOver scene - ")
     }
 
     create() 
@@ -25,21 +25,10 @@ export default class GameOver extends blankScene
         const{width,height} = this.scale
 
         // compone el titulo del final
-        this.add.text(width * 0.5, height * 0.5, 'Game Over', {
-                fontSize: 22,
-                fontFamily: 'Pixeled',
-                fontStyle: 'bold', 
-                color: '#88ff88'
-            })
-            .setOrigin(0.5)
+        this.addText(width * 0.5, height * 0.5, 'Game Over', 22, '#88ff88', 'Pixeled', 'bold')
 
         // play again text
-        this.add.text(width * 0.5, height - 25, 'Press space to play again', {
-                fontSize: 8,
-                fontFamily: 'Pixeled',
-                color: '#FFFFFF'
-            })
-            .setOrigin(0.5)
+        this.addText(width * 0.5, height - 25, 'Press space to play again', 8, '#FFFFFF', 'Pixeled')
 
         // click to play again
         this.input.keyboard.once('keydown-SPACE', () => {

--- a/src/scenes/gameOver.js
+++ b/src/scenes/gameOver.js
@@ -1,13 +1,17 @@
-export default class GameOver extends Phaser.Scene 
+import blankScene from "./scene.js";
+
+export default class GameOver extends blankScene 
 {
     /**
      * Constructor de la escena
      */
     constructor() 
     {
-        super({
-            key: 'GameOver'
-        });
+        super('GameOver');
+    }
+
+    init() {
+        super.init();
     }
 
     preload() 
@@ -45,7 +49,7 @@ export default class GameOver extends Phaser.Scene
 
     update() 
     {
-        
+        super.update();
     }
 
 }

--- a/src/scenes/mainMenu.js
+++ b/src/scenes/mainMenu.js
@@ -1,0 +1,40 @@
+import blankMenu from "./menu.js";
+import { initGame } from "../utils/callbacks.js";
+
+export default class Menu extends blankMenu
+{
+    constructor() 
+    {
+        super('menuGame');
+    }
+
+    init() {
+        super.init();
+    }
+
+    preload() 
+    {
+        console.log(" - mainMenu scene - ")
+    }
+
+    create() 
+    {
+        // gets the sizes of the screen
+        const{width,height} = this.scale
+
+        // Create background image
+        this.background = this.createBackground('img_back');
+
+        // compone el titulo y subtitulo del menu principal del juego
+        this.addText(width * 0.5, 40, 'FORGOTTEN DEBRIS', 24);
+
+        // three buttons, three levels on difficulty (0.35, 0.55, 0.75)
+        this.createButtonGame(width * 0.5, height * 0.45, 'button', 'Jugar', initGame, this);
+        this.createButtonGame(width * 0.5, height * 0.65, 'button', 'Opciones', initGame, this);
+    }
+
+    update() 
+    {
+        super.update();
+    }
+}

--- a/src/scenes/menu.js
+++ b/src/scenes/menu.js
@@ -1,17 +1,17 @@
-export default class Menu extends Phaser.Scene 
+import blankScene from "./scene.js";
+
+export default class Menu extends blankScene
 {
     /**
      * Constructor de la escena
      */
     constructor() 
     {
-        super({
-            key: 'menuGame'
-        });
+        super('menuGame');
     }
 
     init() {
-        this.p = this.input.keyboard.addKey('P');
+        super.init();
     }
 
     preload() 
@@ -38,20 +38,11 @@ export default class Menu extends Phaser.Scene
         // three buttons, three levels on difficulty (0.35, 0.55, 0.75)
         this.createButtonGame(width * 0.5, height * 0.45, 'button', 'Jugar', 3)
         this.createButtonGame(width * 0.5, height * 0.65, 'button', 'Opciones', 3)
-
-        // pause ctrl
-        this.active = true;
-        this.events.on('resume', () => {
-            this.active = true;
-        })
     }
 
     update() 
     {
-        if (this.p.isDown) {
-            const evt = createEvent('pause');
-            document.dispatchEvent(evt);
-        }
+        super.update();
     }
 
     /**
@@ -62,17 +53,6 @@ export default class Menu extends Phaser.Scene
         // inits the game main scene
         this.scene.start('pvliGame', lv)
         this.active = false;
-    }
-
-    isActive() { return this.active; }
-    toggleActive() { this.active = !this.active; }
-
-    handlePause() {
-        // pause logic
-        this.scene.pause();
-        this.scene.launch('blankPause');
-        this.active = false;
-        console.log("PAUSE");
     }
 
     /**

--- a/src/scenes/menu.js
+++ b/src/scenes/menu.js
@@ -1,58 +1,28 @@
 import blankScene from "./scene.js";
 
-export default class Menu extends blankScene
+export default class blankMenu extends blankScene
 {
-    /**
-     * Constructor de la escena
-     */
-    constructor() 
+    constructor(keyname) 
     {
-        super('menuGame');
+        super(keyname);
     }
 
-    init() {
+    init()
+    {
         super.init();
     }
 
     preload() 
     {
-        console.log(" - Menu scene - ")
     }
 
     create() 
     {
-        // gets the sizes of the screen
-        const{width,height} = this.scale
-
-        // Create background image
-        this.background = this.createBackground('img_back');
-
-        // compone el titulo y subtitulo del menu principal del juego
-        this.add.text(width * 0.5, 40, 'FORGOTTEN DEBRIS', {
-                fontSize: 24,
-                fontFamily: 'Greconian',
-                color: '#FFFFFF'
-            })
-            .setOrigin(0.5)
-
-        // three buttons, three levels on difficulty (0.35, 0.55, 0.75)
-        this.createButtonGame(width * 0.5, height * 0.45, 'button', 'Jugar', 3)
-        this.createButtonGame(width * 0.5, height * 0.65, 'button', 'Opciones', 3)
     }
 
-    update() 
+    update(t, dt) 
     {
-        super.update();
-    }
-
-    /**
-    * @param {number} lv Nivel de dificultad
-     */
-    initGame(lv)
-    {
-        // inits the game main scene
-        this.scene.start('pvliGame', lv)
-        this.active = false;
+        super.update(t, dt);
     }
 
     /**
@@ -60,44 +30,67 @@ export default class Menu extends blankScene
      * @param {number} x Coordenada X
      * @param {number} y Coordenada Y
      * @param {Phaser.Textures.Texture} texture Textura usada en el fondo del button (image)
-     * @param {String} name Texto ubicado en en el button
-     * @param {number} lv Nivel de dificultad
+     * @param {String} text Texto ubicado en en el button
+     * @param {Function} fn Callback a ejecutar
+     * @param {Scene} scene Escena del ámbito de uso del botón
+     * @param {any} v Variable auxiliar
      */
-    createButtonGame(x, y, texture, name, lv)
+    createButtonGame(x, y, texture, text, fn, scene, v)
     {
         // crea el button y lo hace interactivo
         this.add.image(x, y, texture)
             .setInteractive()
             .on(Phaser.Input.Events.GAMEOBJECT_POINTER_DOWN, ()=>{
-                this.initGame(lv)
+                fn(scene, v);
             })
-            .setScale(1.25, 0.75) // para el dibujo hecho en paint
-            // .setScale(0.5, 0.3) // para la imagen descargada actual
-
+            .setScale(1.25, 0.75) // usando el placeholder actual
+ 
         // selecciona el color del texto
-        let _color = ''
-        if (lv == 1) _color = '#4444FF'
-        else if (lv == 2) _color = '#00FF00'
-        else if (lv == 3) _color = '#FF0000'
-
+        let _color = '#DD1111'
+ 
         // compone el button con un texto
-        this.add.text(x, y, name, {
-                fontSize: 16,
-                fontFamily: 'Greconian',
-                color: _color
-            })
-            .setOrigin(0.5)
+        this.addText(x, y, text, 16,  _color);
     }
 
     /**
-     * Crea una imagen y la ajusta al fondo
-     * @param {String} keymap Nombre dado a la imagen del fondo en boot 
+     * Crea una línea de texto
+     * @param {number} x Posición horizontal
+     * @param {number} y Posición vertical
+     * @param {String} text Lo que se va a escribir
+     * @param {number} size Tamaño de letra
+     * @param {Color} color Código hexadecimal
+     * @param {String} fuente Fuente creada en CSS
      */
-    createBackground(keymap){
-        // gets the sizes of the screen
-        const{width,height} = this.scale
-
-        this.add.image(width/2, height/2, keymap)
+    addText(x, y, text, size, color = '#FFFFFF', fuente = 'Greconian', style = 'normal') {
+        this.add.text(x, y, text, {
+            fontSize: size,
+            fontStyle: style,
+            fontFamily: fuente,
+            color: color
+        })
+        .setOrigin(0.5)
     }
-    
-}
+
+    /**
+     * Paleta de colores preestablecidos
+     * @param {Number} N índice del color
+     * @returns color seleccionado
+     */
+    color(N) {
+        let _color = '';
+        switch(N) {
+            case 0:
+                _color = '#4444FF'
+                break;
+            case 1:
+                _color = '#00FF00'
+                break;
+            case 2:
+                _color = '#FF0000'
+                break;
+            default:
+                break;
+        }
+        return _color;
+    }
+};

--- a/src/scenes/pause.js
+++ b/src/scenes/pause.js
@@ -19,7 +19,7 @@ export default class blankPause extends blankScene
 
     preload() 
     {
-        console.log("blankPause scene")
+        console.log(" - blankPause scene - ")
     }
 
     create() 

--- a/src/scenes/pvliGame.js
+++ b/src/scenes/pvliGame.js
@@ -2,8 +2,9 @@ import Object from '../game/object.js'
 import PlayerContainer from '../game/playerContainer.js'
 import Bullet from '../game/bullet.js'
 import Hound from '../game/hound.js'
+import blankScene from './scene.js'
 
-export default class pvliGame extends Phaser.Scene 
+export default class pvliGame extends blankScene
 {
     // --- PLAYER --- 
     /** @type {Phaser.GameObjects.Container} */
@@ -32,7 +33,6 @@ export default class pvliGame extends Phaser.Scene
 
     // --- TIMER --- 
     /** @type {Number} */
-    timeLapsed
     cooldownAsteroids
 
     // --- UI --- 
@@ -45,21 +45,18 @@ export default class pvliGame extends Phaser.Scene
     objectCollected
     objectToFinish
 
-    /** @type {boolean} */
-    active
-
     /**
      * Constructor de la escena
      */
     constructor() 
     {
-        super({
-            key: 'pvliGame'
-        });
+        super('pvliGame');
     }
 
     init(level)
     {
+        super.init();
+
         // Level select assignment
         this.level = level
         console.log('Level = ' + this.level)
@@ -86,8 +83,6 @@ export default class pvliGame extends Phaser.Scene
 
         // cancela las colisiones con el techo
         this.physics.world.checkCollision.up = false
-
-        this.p = this.input.keyboard.addKey('P');
     }
 
     preload() 
@@ -120,45 +115,11 @@ export default class pvliGame extends Phaser.Scene
         //this.poti = new Potion(this, 100, 100)
         // Creates the Score UI
         // this.createScoreUI()
-
-        // Inits the timer
-        this.timeLapsed = 0
-
-        // pause ctrl
-        this.active = true;
-        this.events.on('resume', () => {
-            this.active = true;
-        });
     }
 
     update(t, dt) 
     {
-        // actualiza el timer
-        this.timeLapsed = this.timeLapsed + dt
-
-        // Cooldown to create a new bullet
-        // if (this.timeLapsed > this.cooldownAsteroids)
-        // {
-        //     this.createRandomBullet(this.map)
-        //     this.timeLapsed = 0
-        // }        
-        // this.input.keyboard.on('keydown_P', this.handlePause, this);
-
-        if (this.p.isDown) {
-            const evt = createEvent('pause');
-            document.dispatchEvent(evt);
-        }
-    }
-
-    isActive() { return this.active; }
-    toggleActive() { this.active = !this.active; }
-
-    handlePause() {
-        // pause logic
-        this.scene.pause();
-        this.scene.launch('blankPause');
-        this.active = false;
-        console.log("PAUSE");
+        super.update(t,dt);
     }
 
     /**

--- a/src/scenes/pvliGame.js
+++ b/src/scenes/pvliGame.js
@@ -87,7 +87,7 @@ export default class pvliGame extends blankScene
 
     preload() 
     {
-        console.log("pvliGame scene")
+        console.log(" - pvliGame scene - ")
     }
 
     create() 

--- a/src/scenes/scene.js
+++ b/src/scenes/scene.js
@@ -18,7 +18,9 @@ export default class blankScene extends Phaser.Scene
     init()
     {
         this.timeLapsed = 0;
-        this.setPauseCtrl();
+        this.active = false;
+        this.p = this.input.keyboard.addKey('P');
+        this.setSceneEvents();
     }
 
     preload() 
@@ -40,6 +42,7 @@ export default class blankScene extends Phaser.Scene
         }
     }
 
+    // --- --- TIMER SYSTEM --- --- 
     cooldown(keyTime, fn) {
         if (this.timeLapsed > keyTime)
         {
@@ -47,10 +50,12 @@ export default class blankScene extends Phaser.Scene
             this.timeLapsed = 0;
         }
     }
+    // --- --- --- 
 
-    setPauseCtrl() {
-        this.p = this.input.keyboard.addKey('P');
-        this.active = true;      
+    // --- --- PAUSE SYSTEM --- --- 
+    setSceneEvents() {             
+        this.events.on('start', () => { this.active = true; });
+        this.events.on('create', () => { this.active = true; });
         this.events.on('resume', () => { this.active = true; });
         this.events.on('pause', () => { this.active = false; });
         this.events.on('shutdown', () => { this.active = false; });
@@ -62,10 +67,22 @@ export default class blankScene extends Phaser.Scene
     handlePause() {
         this.scene.pause();
         this.scene.launch('blankPause');
+        // this.scene.start('blankPause');
     }
 
     handleResume(scene) {
         this.scene.resume(scene);
         this.scene.stop();
+        // this.scene.start(scene);
+    }
+    // --- --- --- 
+
+    /**
+     * Crea una imagen y la ajusta al fondo
+     * @param {String} keymap Nombre dado a la imagen del fondo en boot 
+     */
+    createBackground(keymap){
+        const{width,height} = this.scale
+        this.add.image(width/2, height/2, keymap)
     }
 };

--- a/src/scenes/scene.js
+++ b/src/scenes/scene.js
@@ -1,0 +1,71 @@
+export default class blankScene extends Phaser.Scene
+{
+    // --- TIMER --- 
+    /** @type {Number} */
+    timeLapsed
+
+    // --- ACTIVITY --- 
+    /** @type {boolean} */
+    active
+
+    constructor(keyname) 
+    {
+        super({
+            key: keyname
+        });
+    }
+
+    init()
+    {
+        this.timeLapsed = 0;
+        this.setPauseCtrl();
+    }
+
+    preload() 
+    {
+        console.log(key + " scene")
+    }
+
+    create() 
+    {
+    }
+
+    update(t, dt) 
+    {
+        this.timeLapsed = this.timeLapsed + dt; // UPDATE TIMER
+
+        if (this.p.isDown) {
+            const evt = createEvent('pause');
+            document.dispatchEvent(evt);
+        }
+    }
+
+    cooldown(keyTime, fn) {
+        if (this.timeLapsed > keyTime)
+        {
+            fn();
+            this.timeLapsed = 0;
+        }
+    }
+
+    setPauseCtrl() {
+        this.p = this.input.keyboard.addKey('P');
+        this.active = true;      
+        this.events.on('resume', () => { this.active = true; });
+        this.events.on('pause', () => { this.active = false; });
+        this.events.on('shutdown', () => { this.active = false; });
+    }
+
+    isActive() { return this.active; }
+    toggleActive() { this.active = !this.active; }
+
+    handlePause() {
+        this.scene.pause();
+        this.scene.launch('blankPause');
+    }
+
+    handleResume(scene) {
+        this.scene.resume(scene);
+        this.scene.stop();
+    }
+};


### PR DESCRIPTION
Tratando de unificar las funcionalidades comunes para los distintos tipos de escenas, se han creado tres clases principales:

1. `blankScene`: es la escena más básica, extiende la funcionalidad de `Phaser.Scene`. Esta clase principalmente maneja todo el cambio entre escenas comentado en el pull-request [#4 - Cambio entre escenas Phaser y elementos DOM](https://github.com/Acedpol/PVLI-2022-23/pull/4), el TIMER que es esencial para funciones tipo _cooldown_ y un método para deinir un fondo que cubra toda la pantalla a partir de una imagen.
2. `blankMenu`: es la escena de tipo menú más básica, extiende la funcionalidad de `blankScene`. Esta clase contiene los métodos necesarios para crear botones y líneas de texto, lo que simplifica el desarrollo de un nuevo menú.
3. `blankPause`: es la escena de tipo pausa más básica, extiende la funcionalidad de `blankScene`. Esta clase sobreescribe el método `handleResume()` que permite volver a la escena pausada, pero tiene en cuenta cerrar el panel superpuesto del DOM.